### PR TITLE
Using output of trim step for SHA

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -24,7 +24,7 @@ jobs:
           VITE_FB_STORAGE_BUCKET: ${{ secrets.VITE_FB_STORAGE_BUCKET }}
           VITE_FB_SENDER_ID: ${{ secrets.VITE_FB_SENDER_ID }}
           VITE_FB_APP_ID: ${{ secrets.VITE_FB_APP_ID }}
-          VITE_GITHUB_SHA: ${{ github.sha }}
+          VITE_GITHUB_SHA: ${{ steps.trimSHA.outputs.trim_sha }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
GitHub Action now accidentally uses the un-trimmed SHA as environment variable to display on the website.