### PR TITLE
Fix logout

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { RouterView, useRouter } from "vue-router";
 import { ref } from "vue";
-import { getAuth } from "@firebase/auth";
+import { useCurrentUser, useFirebaseAuth } from "vuefire";
 
 const leftDrawerOpen = ref(false);
 const commitID = import.meta.env.VITE_GITHUB_SHA;
@@ -10,9 +10,13 @@ function toggleLeftDrawer() {
   leftDrawerOpen.value = !leftDrawerOpen.value;
 }
 
+const user = useCurrentUser();
+
 const router = useRouter();
-function signOut() {
-  getAuth().signOut();
+const signOutLoading = ref(false);
+async function signOut() {
+  signOutLoading.value = true;
+  await useFirebaseAuth()!.signOut();
   router.replace("/login");
 }
 </script>
@@ -30,7 +34,11 @@ function signOut() {
           class="lt-md"
         />
         <q-toolbar-title></q-toolbar-title>
-        <q-btn flat label="Sign Out" @click="signOut" />
+        <q-btn flat label="Sign Out" @click="signOut" :loading="signOutLoading"
+          ><q-tooltip class="text-caption"
+            >Sign out of {{ user?.email }}</q-tooltip
+          ></q-btn
+        >
       </q-toolbar>
     </q-header>
 

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
-import {
-  getAuth,
-  GoogleAuthProvider,
-  signInWithRedirect,
-} from "@firebase/auth";
+import { GoogleAuthProvider, signInWithRedirect } from "@firebase/auth";
 import { ref } from "vue";
+import { useFirebaseAuth } from "vuefire";
 
 const redirectLoading = ref(false);
 function redirectForOAuth() {
   redirectLoading.value = true;
-  signInWithRedirect(getAuth(), new GoogleAuthProvider());
+  signInWithRedirect(useFirebaseAuth()!, new GoogleAuthProvider());
 }
 </script>
 


### PR DESCRIPTION
Not realizing that signing out on Firebase is an async, the redirect to the login page was carried out before the promise to log out was resolved leading to a strange state. This has been fixed by awaiting the promise before redirecting the user.

A tooltip was also added on the sign out button to show the user which email was used to log in.