### PR TITLE
added month selector and table for monthly view

### DIFF
--- a/src/components/DateSelector.vue
+++ b/src/components/DateSelector.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import dayjs from "dayjs";
+
+const props = defineProps<{
+  selected_date: string;
+}>();
+const emit = defineEmits<{
+  (e: "dateChange", date: string): void;
+}>();
+
+let model_date = ref(props.selected_date);
+
+watch(props, (new_props) => {
+  model_date.value = new_props.selected_date;
+});
+watch(model_date, (new_model_date) => {
+  emit("dateChange", new_model_date);
+});
+
+function navigateMonth(delta: number) {
+  let current = dayjs(`${model_date.value}-01`);
+  model_date.value = current.add(delta, "month").format("YYYY-MM");
+}
+</script>
+
+<template>
+  <div class="row flex-center">
+    <q-input
+      filled
+      v-model="model_date"
+      type="month"
+      style="text-align: center"
+      class="col-3"
+    >
+      <template v-slot:prepend>
+        <div>
+          <q-btn
+            @click="navigateMonth(-1)"
+            flat
+            round
+            color="primary"
+            icon="chevron_left"
+            class="col-2"
+          />
+        </div>
+      </template>
+      <template v-slot:append>
+        <div>
+          <q-btn
+            @click="navigateMonth(1)"
+            flat
+            round
+            color="primary"
+            icon="chevron_right"
+            class="col-2"
+          />
+        </div>
+      </template>
+    </q-input>
+  </div>
+</template>

--- a/src/components/DateSelector.vue
+++ b/src/components/DateSelector.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+//@ts-nocheck
 import { ref, watch } from "vue";
 import dayjs from "dayjs";
 

--- a/src/components/DateSelector.vue
+++ b/src/components/DateSelector.vue
@@ -31,30 +31,25 @@ function navigateMonth(delta: number) {
       v-model="model_date"
       type="month"
       style="text-align: center"
-      class="col-3"
+      class="col-12 col-md-3"
     >
       <template v-slot:prepend>
-        <div>
-          <q-btn
-            @click="navigateMonth(-1)"
-            flat
-            round
-            color="primary"
-            icon="chevron_left"
-            class="col-2"
-          />
-        </div>
-      </template>
-      <template v-slot:append>
-        <div>
-          <q-btn
-            @click="navigateMonth(1)"
-            flat
-            round
-            color="primary"
-            icon="chevron_right"
-            class="col-2"
-          />
+        <div class="q-pr-md">
+          <q-btn-group flat>
+            <q-btn
+              @click="navigateMonth(-1)"
+              flat
+              round
+              color="primary"
+              icon="chevron_left"
+            /><q-btn
+              @click="navigateMonth(1)"
+              flat
+              round
+              color="primary"
+              icon="chevron_right"
+            />
+          </q-btn-group>
         </div>
       </template>
     </q-input>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import LoginView from "@/views/LoginView.vue";
 import MonthView from "@/views/MonthView.vue";
 import { getCurrentUser } from "vuefire";
 import dayjs from "dayjs";
+import JournalEntryView from "@/views/JournalEntryView.vue";
 
 const date = dayjs();
 const router = createRouter({
@@ -16,10 +17,15 @@ const router = createRouter({
       redirect: `journal/${date.format("YYYY-MM")}`,
       children: [
         {
-          path: "journal/:date?",
+          path: "journal/:date(\\d{4}-\\d{2})",
           component: MonthView,
           name: "month-view",
           props: true,
+        },
+        {
+          path: "journal/:date(\\d{4}-\\d{2}-\\d{2})",
+          name: "entry-view",
+          component: JournalEntryView,
         },
       ],
     },

--- a/src/views/MonthView.vue
+++ b/src/views/MonthView.vue
@@ -39,6 +39,30 @@ function queryJournalEntries() {
   entries = useCollection(q, { ssrKey: "date" });
 }
 queryJournalEntries();
+
+const columns = [
+  {
+    name: "date",
+    required: true,
+    align: "left",
+    label: "Date",
+  },
+  {
+    name: "section_name",
+    align: "left",
+    label: "Sections",
+  },
+  {
+    name: "title",
+    align: "left",
+    label: "Title",
+  },
+  {
+    name: "rating",
+    align: "left",
+    label: "Rating",
+  },
+];
 </script>
 
 <template>
@@ -49,7 +73,38 @@ queryJournalEntries();
     />
   </div>
   <div class="q-ma-lg">
-    {{ entries }}
-    <!-- <JournalEntryView date="" /> -->
+    <q-table title="Entries" :rows="entries" :columns="columns" row-key="date">
+      <template v-slot:body="props">
+        <q-tr :props="props" @click="router.push(`${props.row.date}`)">
+          <q-td key="date" :props="props">
+            {{ props.row.date }}
+          </q-td>
+          <q-td :props="props" key="date">
+            <ul style="list-style-type: none; padding: 0; margin: 0">
+              <li
+                v-for="section in props.row.sections"
+                :key="section.section_name"
+              >
+                {{ section.section_name }}
+              </li>
+            </ul>
+          </q-td>
+          <q-td :props="props" key="date">
+            <ul style="list-style-type: ''; padding: 0; margin: 0">
+              <li v-for="section in props.row.sections" :key="section.title">
+                {{ section.title }}
+              </li>
+            </ul>
+          </q-td>
+          <q-td :props="props" key="date">
+            <ul style="list-style-type: ''; padding: 0; margin: 0">
+              <li v-for="section in props.row.sections" :key="section.rating">
+                {{ section.rating }}
+              </li>
+            </ul>
+          </q-td>
+        </q-tr>
+      </template>
+    </q-table>
   </div>
 </template>

--- a/src/views/MonthView.vue
+++ b/src/views/MonthView.vue
@@ -2,7 +2,7 @@
 import JournalEntryView from "@/views/JournalEntryView.vue";
 import { useCollection, useCurrentUser, type _RefFirestore } from "vuefire";
 import { useRouter } from "vue-router";
-import { watch } from "vue";
+import { ref, watch } from "vue";
 import {
   collection,
   query,
@@ -12,6 +12,7 @@ import {
   endAt,
 } from "@firebase/firestore";
 import { db } from "@/firebase/fb-init";
+import DateSelector from "@/components/DateSelector.vue";
 
 const user = useCurrentUser();
 const router = useRouter();
@@ -21,7 +22,6 @@ const props = defineProps<{
 }>();
 
 watch(props, (new_date) => {
-  console.log(`date has been changed to ${new_date.date}`);
   queryJournalEntries();
 });
 
@@ -33,8 +33,8 @@ function queryJournalEntries() {
   const q = query(
     journalMonthRef,
     orderBy("date"),
-    startAt("2022-01-01"),
-    endAt("2023-04-15")
+    startAt(`${props.date}-01`),
+    endAt(`${props.date}-31`)
   );
   entries = useCollection(q, { ssrKey: "date" });
 }
@@ -43,6 +43,13 @@ queryJournalEntries();
 
 <template>
   <div class="q-ma-lg">
-    <JournalEntryView date="" />
+    <DateSelector
+      @date-change="(new_date) => router.push(`/journal/${new_date}`)"
+      :selected_date="props.date"
+    />
+  </div>
+  <div class="q-ma-lg">
+    {{ entries }}
+    <!-- <JournalEntryView date="" /> -->
   </div>
 </template>

--- a/src/views/MonthView.vue
+++ b/src/views/MonthView.vue
@@ -43,24 +43,23 @@ queryJournalEntries();
 const columns = [
   {
     name: "date",
-    required: true,
-    align: "left",
     label: "Date",
+    field: "date",
   },
   {
     name: "section_name",
-    align: "left",
     label: "Sections",
+    field: "sections",
   },
   {
     name: "title",
-    align: "left",
     label: "Title",
+    field: "sections",
   },
   {
     name: "rating",
-    align: "left",
     label: "Rating",
+    field: "sections",
   },
 ];
 </script>


### PR DESCRIPTION
The default path now shows all the entries for the current month and the selector on top allows the user to navigate between months. Clicking on a row in the table of entries also redirects to the user to the WIP entry page.