### PR TITLE
using pinia to store montly entries

### DIFF
--- a/src/stores/monthly-entries.ts
+++ b/src/stores/monthly-entries.ts
@@ -21,7 +21,6 @@ export const useMonthlyEntriesStore = defineStore("monthly-entries", () => {
   function getJournalEntries(month: string) {
     if (month != currently_loaded_month) {
       currently_loaded_month = month;
-      console.log("Updating monthly view from server!");
       monthlyEntries.value = useCollection(
         query(
           journalMonthRef,

--- a/src/stores/monthly-entries.ts
+++ b/src/stores/monthly-entries.ts
@@ -1,0 +1,39 @@
+import { db } from "@/firebase/fb-init";
+import {
+  collection,
+  query,
+  orderBy,
+  startAt,
+  endAt,
+} from "@firebase/firestore";
+import type { DocumentData } from "firebase/firestore";
+import { defineStore } from "pinia";
+import { ref, type Ref } from "vue";
+import { useCollection, useCurrentUser, type _RefFirestore } from "vuefire";
+
+export const useMonthlyEntriesStore = defineStore("monthly-entries", () => {
+  const monthlyEntries: Ref<any> = ref([]);
+
+  let currently_loaded_month = "";
+  const user = useCurrentUser();
+  const journalMonthRef = collection(db, `/users/${user.value?.uid}/entries`);
+
+  function getJournalEntries(month: string) {
+    if (month != currently_loaded_month) {
+      currently_loaded_month = month;
+      console.log("Updating monthly view from server!");
+      monthlyEntries.value = useCollection(
+        query(
+          journalMonthRef,
+          orderBy("date"),
+          startAt(`${month}-01`),
+          endAt(`${month}-31`)
+        ),
+        {
+          ssrKey: "date",
+        }
+      );
+    }
+  }
+  return { monthlyEntries, getJournalEntries };
+});

--- a/src/views/JournalEntryView.vue
+++ b/src/views/JournalEntryView.vue
@@ -2,9 +2,11 @@
 import { db } from "@/firebase/fb-init";
 import { addDoc, collection } from "@firebase/firestore";
 import { ref } from "vue";
+import { useRouter } from "vue-router";
 import { useCurrentUser } from "vuefire";
 
 let user = useCurrentUser();
+let router = useRouter();
 
 type JournalEntryTab = {
   section_name: string;
@@ -49,6 +51,7 @@ function addEntry() {
 </script>
 <template>
   <q-card>
+    <q-btn icon="arrow_left" @click="router.back()" />
     <q-card-section>
       <q-input
         v-model="entry_date"

--- a/src/views/MonthView.vue
+++ b/src/views/MonthView.vue
@@ -1,45 +1,24 @@
 <script setup lang="ts">
 import JournalEntryView from "@/views/JournalEntryView.vue";
-import { useCollection, useCurrentUser, type _RefFirestore } from "vuefire";
 import { useRouter } from "vue-router";
-import { ref, watch } from "vue";
-import {
-  collection,
-  query,
-  type DocumentData,
-  orderBy,
-  startAt,
-  endAt,
-} from "@firebase/firestore";
-import { db } from "@/firebase/fb-init";
+import { watch } from "vue";
+
 import DateSelector from "@/components/DateSelector.vue";
 import type { QTableProps } from "quasar";
+import { useMonthlyEntriesStore } from "@/stores/monthly-entries";
 
-const user = useCurrentUser();
 const router = useRouter();
 
 const props = defineProps<{
   date: string;
 }>();
 
-watch(props, (new_date) => {
-  queryJournalEntries();
+const monthlyStore = useMonthlyEntriesStore();
+monthlyStore.getJournalEntries(props.date);
+
+watch(props, (new_props) => {
+  monthlyStore.getJournalEntries(new_props.date);
 });
-
-const journalMonthRef = collection(db, `/users/${user.value?.uid}/entries`);
-
-let entries: _RefFirestore<DocumentData[]>;
-
-function queryJournalEntries() {
-  const q = query(
-    journalMonthRef,
-    orderBy("date"),
-    startAt(`${props.date}-01`),
-    endAt(`${props.date}-31`)
-  );
-  entries = useCollection(q, { ssrKey: "date" });
-}
-queryJournalEntries();
 
 const columns: QTableProps["columns"] = [
   {
@@ -80,7 +59,7 @@ const columns: QTableProps["columns"] = [
     <div class="col-12 col-md-10">
       <q-table
         title="Entries"
-        :rows="entries"
+        :rows="monthlyStore.monthlyEntries.value"
         :columns="columns"
         row-key="date"
       >


### PR DESCRIPTION
Now that the monthly entries are stored in Pinia, different components can access them without reloading the data thereby reducing the number of reads on the Firestore table.